### PR TITLE
Fix examples, fix markdown and fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: perl
 perl:
+  - "5.30"
+  - "5.28"
   - "5.26"
   - "5.24"
   - "5.22"
-  - "5.20"
 branches:
   only:
     - master
     - develop
 install:
-  - "cpanm -n Text::Markdown Test::Pod Test::Pod::Coverage"
+  - "cpanm -n Text::Markdown Test::Pod Test::Pod::Coverage" 
   - "cpanm -n --installdeps ."
 notifications:
   email: sugama@jamadam.com

--- a/examples/AuthPretty/auth_pretty.pl
+++ b/examples/AuthPretty/auth_pretty.pl
@@ -19,11 +19,13 @@ use utf8;
 use File::Basename 'dirname';
 use File::Spec;
 use Mojo::Base 'Marquee';
+use feature 'signatures';
+no warnings 'experimental::signatures';
 
 sub new($class, @args) {
     my $self = $class->SUPER::new(@args);
     
-    $self->document_root($self->home->rel_dir('.'));
+    $self->document_root($self->home->rel_file('.'));
     $self->default_file('index.html');
     $self->log_file(File::Spec->rel2abs(dirname(__FILE__). "/log/Marquee.log"));
     
@@ -36,7 +38,7 @@ sub new($class, @args) {
     });
     
     $self->plugin(AuthPretty => [
-        qr{^/admin/} => 'Secret Area' => sub($username, $password) {
+        qr{^/admin/} => 'Secret Area' => sub($username,$password) {
             return $username eq 'jamadam' && $password eq 'pass';
         },
     ] => File::Spec->rel2abs(dirname(__FILE__). "/log/auth_pretty"));

--- a/examples/simple/myapp.pl
+++ b/examples/simple/myapp.pl
@@ -10,9 +10,9 @@ use Marquee;
 $ENV{MOJO_HOME} = File::Spec->rel2abs(dirname(__FILE__));
 
 my $app = Marquee->new;
-$app->document_root($app->home->rel_dir('public_html'));
+$app->document_root($app->home->rel_file('public_html'));
 $app->log_file(File::Spec->rel2abs(dirname(__FILE__). "/log/Marquee.log"));
 $app->default_file('index.html');
 $app->plugin('AutoIndex');
-$app->config(hypnotoad => {listen => ['http://*:8002']});
+#$app->config(hypnotoad => {listen => ['http://*:8002']});
 $app->start;

--- a/readme.md
+++ b/readme.md
@@ -99,8 +99,7 @@ Here is some screenshots of how Marquee look like.
 
 ## REPOSITORY
 
-[https://github.com/jamadam/Marquee]
-[https://github.com/jamadam/Marquee]:https://github.com/jamadam/Marquee
+[Marquee](https://github.com/jamadam/Marquee)
 
 ## CREDIT
 


### PR DESCRIPTION
Hello,

I just tried to run provided examples and I needed to adapt a bit the code to make them work so here is my retrofits. Seems like rel_dir was removed from Mojolicious (I see a lot of other occurences in the "main application", it should probably be modified also). 
Please note that I don't know what's wrong with $app->config (where is it supposed to be declared or when/where it was deleted) so I just commented it.

I also took the liberty to fix the markdown for the readme.

Regards.

Thibault
