### PR TITLE
Fix smallest Marquee application in the cookbook

### DIFF
--- a/lib/Marquee/Guides/Cookbook.pod
+++ b/lib/Marquee/Guides/Cookbook.pod
@@ -15,9 +15,18 @@ This document contains some recipes to develop Marquee application.
 Here is a smallest Marquee application.
 
     use Marquee;
+
+    my $app = Marquee->new(document_root => '/tmp');
+
+    $app->start;
     
+Or alternatively :
+    
+    use Marquee;
+
     my $app = Marquee->new;
-    
+    $app->document_root('/tmp');
+
     $app->start;
 
 You also can separate the app into a class (shown below) and


### PR DESCRIPTION
Hello again, 

The current sample for "Smallest Marquee application" is not correct as we have to provide a document_root or it will die at init. 

I prefered to edit the documentation, but we could imagine defaulting to application directory (in lib/Marquee.pm sub _init($self) before line 307) -> I did not dare to go for this edit but it' s probably the best solution. What do you think ?

